### PR TITLE
Add ReadTheDoc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Neptune
+# Neptune Documentation
+
+## ReadTheDocs
+
+The documentation in this repository is automatically rendered at [Read the
+Docs](https://excalibur-neptune.readthedocs.io/en/latest/).
+
+Each branch and pull request is also rendered. To view these, go to the [Read
+the Docs](https://excalibur-neptune.readthedocs.io/en/latest/) page, and then
+click on "Read the Docs" at the bottom of the sidebar.
+Click "Builds" (under "On Read the Docs") and select the relevant branch or pull request from the list.
+Click on the small grey "View Docs" link to the right of the "Build Completed"
+badge.
+The page should render with an orange banner, warning that you are viewing a
+branch or a PR.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,8 @@
 The documentation in this repository is automatically rendered at [Read the
 Docs](https://excalibur-neptune.readthedocs.io/en/latest/).
 
-Each branch and pull request is also rendered. To view these, go to the [Read
-the Docs](https://excalibur-neptune.readthedocs.io/en/latest/) page, and then
-click on "Read the Docs" at the bottom of the sidebar.
-Click "Builds" (under "On Read the Docs") and select the relevant branch or pull request from the list.
-Click on the small grey "View Docs" link to the right of the "Build Completed"
-badge.
-The page should render with an orange banner, warning that you are viewing a
-branch or a PR.
+Each pull request is also rendered automatically.
+To view a PR's documentation, go to the review section at the bottom of the PR,
+and click on "Show all checks".
+On the Read the Docs line, click the "Details" link.
+The page should render with an orange banner warning that you are viewing the PR's documentaion.


### PR DESCRIPTION
Add link to ReadTheDocs pages in the README.  Also add instructions for viewing the ReadTheDocs pages for branches and PRs.